### PR TITLE
Fix incorrect link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ import {MailSlurp} from "mailslurp-client";
 
 
 ### 2) Standalone MailSlurp client
-Install the [MailSlurp Javascript library](https://n) and then add MailSlurp as a [custom cypress command](https://docs.cypress.io/api/cypress-api/custom-commands).
+Install the [MailSlurp Javascript library](https://www.npmjs.com/package/mailslurp-client) and then add MailSlurp as a [custom cypress command](https://docs.cypress.io/api/cypress-api/custom-commands).
 
 Install package from npm:
 


### PR DESCRIPTION
The link to the original mailslurp client was incorrect. I think it's the link that was intended, if not, then I'm sorry - but at least you now know that the link is incorrect.

I hope it helps, and thanks for the package.